### PR TITLE
Refine VectorAnswer for vairous vector_document types

### DIFF
--- a/lib/boxcars/boxcar/vector_answer.rb
+++ b/lib/boxcars/boxcar/vector_answer.rb
@@ -7,16 +7,16 @@ module Boxcars
     # the description of this engine boxcar
     DESC = "useful for when you need to answer questions from vector search results."
 
-    attr_reader :embeddings, :vector_documents, :search_content
+    attr_reader :embedding_tool, :vector_documents, :search_content
 
-    # @param embeddings [Hash] The vector embeddings to use for this boxcar.
+    # @param embedding_tool [Symbol] The vector embedding_tool to use for this boxcar.
     # @param vector_documents [Hash] The vector documents to use for this boxcar.
     # @param engine [Boxcars::Engine] The engine to user for this boxcar. Can be inherited from a train if nil.
     # @param prompt [Boxcars::Prompt] The prompt to use for this boxcar. Defaults to built-in prompt.
     # @param kwargs [Hash] Any other keyword arguments to pass to the parent class.
-    def initialize(embeddings:, vector_documents:, engine: nil, prompt: nil, **kwargs)
+    def initialize(embedding_tool:, vector_documents:, engine: nil, prompt: nil, **kwargs)
       the_prompt = prompt || my_prompt
-      @embeddings = embeddings
+      @embedding_tool = embedding_tool
       @vector_documents = vector_documents
       kwargs[:stop] ||= ["```output"]
       kwargs[:name] ||= "VectorAnswer"
@@ -45,7 +45,7 @@ module Boxcars
     # @params count [Integer] The number of results to return.
     # @return [String] The content of the search results.
     def get_search_content(question, count: 1)
-      search = Boxcars::VectorSearch.new(embeddings: embeddings, vector_documents: vector_documents)
+      search = Boxcars::VectorSearch.new(embedding_tool: embedding_tool, vector_documents: vector_documents)
       results = search.call query: question, count: count
       @search_content = get_results_content(results)
     end

--- a/lib/boxcars/vector_search.rb
+++ b/lib/boxcars/vector_search.rb
@@ -6,7 +6,11 @@ module Boxcars
   class VectorSearch
     # initialize the vector search with the following parameters:
     # @param params [Hash] A Hash containing the initial configuration.
-    # @option params [Hash] :vector_documents The vector documents to search.
+    # @option params [Symbol] :embedding_tool The embedding tool to use.  default is :openai
+    # @option params [OpenAI::Client] :openai_connection The openai connection to use.
+    # @options params [String] :openai_access_token The openai access token to use.
+    #                          this will be used if openai_connection is not provided.
+    # @param params [Hash] :vector_documents The vector documents to search.
     # example:
     # {
     #   type: :in_memory,

--- a/spec/boxcars/vector_answer_spec.rb
+++ b/spec/boxcars/vector_answer_spec.rb
@@ -18,5 +18,27 @@ RSpec.describe Boxcars::VectorAnswer do
         expect(vector_answer.run("Will I get a laptop?")).to include("you will be provided with a laptop")
       end
     end
+
+    context 'vector_documents as in_memory vector store' do
+      let(:vector_store_type) { :in_memory }
+      let(:vector_documents) do
+        {
+          type: vector_store_type,
+          vector_store: [
+            Boxcars::VectorStore::Document.new(
+              content: "hello",
+              embedding: [0.1, 0.2, 0.3],
+              metadata: { a: 1 }
+            )
+          ]
+        }
+      end
+
+      it "can answer a question from content" do
+        VCR.use_cassette("vector_answer") do
+          expect(vector_answer.run("Will I get a laptop?")).to include("you will be provided with a laptop")
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Changes

- updated lib/boxcars/boxcar/vector_answer.rb for recent refactoring for vector stores 
- updated specs for various vector store types 

Why?

- vector_answer also needs to be updated 
- provide more exampels in the spec and in notebook
- resolves https://github.com/BoxcarsAI/boxcars/issues/84

Test

- irb console result 
- specs are green